### PR TITLE
use "@babel/plugin-transform-runtime"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,8 @@
     "plugins": [
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }],
-        ["@babel/plugin-proposal-private-methods", { "loose": true }]
+        ["@babel/plugin-proposal-private-methods", { "loose": true }],
+        ["@babel/plugin-transform-runtime", { "loose": true }]
     ],
     "env": {
       "production": {


### PR DESCRIPTION
- use "@babel/plugin-transform-runtime" to avoid requiring regenerator runtime, see https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator-aliasing